### PR TITLE
Need ldap property java.naming.referral

### DIFF
--- a/api/src/main/java/org/intalio/tempo/security/ldap/LDAPAuthenticationProvider.java
+++ b/api/src/main/java/org/intalio/tempo/security/ldap/LDAPAuthenticationProvider.java
@@ -314,6 +314,7 @@ implements AuthenticationProvider, LDAPProperties {
 
                 copyProperty(env, "javax.security.sasl.qop");
                 copyProperty(env, "java.naming.security.sasl.realm");
+		copyProperty(env, "java.naming.referral");
                 copyProperty(env, "javax.security.sasl.strength");
 
                 if (_principleSyntax.equals("url")) {


### PR DESCRIPTION
There is currently no way to specify java.naming.referral. 
It would be even better if all properties where copied, not just the few specified.